### PR TITLE
Refactor: 스케줄 등록폼 모달 상태관리 및 버튼 컴포넌트 코드 리팩토링

### DIFF
--- a/src/common/components/Button/ButtonGroup.tsx
+++ b/src/common/components/Button/ButtonGroup.tsx
@@ -22,11 +22,10 @@ const ButtonGroup = () => {
   const onClickToggle = () => {
     if (url === "/scheduleRegister") {
       setModalType("register");
-      setIsModal(!isModal);
     } else {
-      setIsModal(!isModal);
       setModalType("");
     }
+    setIsModal(!isModal);
   };
 
   const onClickShowModal = () => {

--- a/src/common/components/Button/ButtonGroup.tsx
+++ b/src/common/components/Button/ButtonGroup.tsx
@@ -1,0 +1,91 @@
+import ButtonItem from "@components/Button/Button.tsx";
+import { AddIcon, CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";
+import useStore from "@stores/store.ts";
+import { useLocation } from "react-router-dom";
+import { COLORS } from "@constants/color.ts";
+import React, { useState } from "react";
+import ModalComponent from "@components/Modal/Modal.tsx";
+
+interface ButtonGroupViewProps {
+  isModal: boolean;
+  onClickToggle: () => void;
+  onClickShowModal: () => void;
+  isForRegisterModal: boolean;
+  setIsForRegisterModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ButtonGroup = () => {
+  const url = useLocation().pathname;
+  const { setModalType, isModal, setIsModal } = useStore();
+  const [isForRegisterModal, setIsForRegisterModal] = useState(false);
+
+  const onClickToggle = () => {
+    if (url === "/scheduleRegister") {
+      setModalType("register");
+      setIsModal(!isModal);
+    } else {
+      setIsModal(!isModal);
+      setModalType("");
+    }
+  };
+
+  const onClickShowModal = () => {
+    if (url === "/scheduleRegister") {
+      setIsForRegisterModal(!isForRegisterModal);
+    } else {
+      setModalType("modal");
+    }
+  };
+
+  const props = {
+    isModal,
+    onClickToggle,
+    onClickShowModal,
+    isForRegisterModal,
+    setIsForRegisterModal,
+  };
+  return <ButtonGroupView {...props} />;
+};
+
+const ButtonGroupView = ({
+  isModal,
+  onClickShowModal,
+  onClickToggle,
+  isForRegisterModal,
+  setIsForRegisterModal,
+}: ButtonGroupViewProps) => {
+  return (
+    <>
+      {isForRegisterModal && (
+        <ModalComponent
+          isForRegisterModal={isForRegisterModal}
+          setIsForRegisterModal={setIsForRegisterModal}
+        />
+      )}
+      {isModal && (
+        <>
+          <ButtonItem type="scheduleCancel" onClick={onClickShowModal}>
+            <DeleteIcon color={COLORS.gray700} fontSize={25} />
+          </ButtonItem>
+          <ButtonItem
+            style={{ bottom: "8rem" }}
+            type="toggle"
+            onClick={onClickShowModal}
+          >
+            <EditIcon color={COLORS.white} fontSize={25} />
+          </ButtonItem>
+        </>
+      )}
+
+      <ButtonItem type="toggle" onClick={onClickToggle}>
+        {isModal ? (
+          <CloseIcon color="white" fontSize={16} />
+        ) : (
+          <AddIcon color="white" fontSize={18} />
+        )}
+      </ButtonItem>
+    </>
+  );
+};
+
+export default ButtonGroup;

--- a/src/common/components/Modal/Modal.tsx
+++ b/src/common/components/Modal/Modal.tsx
@@ -10,22 +10,31 @@ import {
 import Typography from "@components/Typography/Typography";
 import { COLORS } from "@constants/color";
 import useStore from "@stores/store";
+import React from "react";
 
 interface ModalViewProps {
   isModal: boolean;
   onClickCloseModal: () => void;
   title: string;
   description: string;
+  isForRegisterModal?: boolean;
+  setIsForRegisterModal?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const ModalComponent = ({
   title = "제목",
   description = "설명",
+  isForRegisterModal,
+  setIsForRegisterModal,
 }: Partial<ModalViewProps>) => {
-  const { isModal, setIsModal } = useStore();
+  const { isModal, setIsModal, setModalType } = useStore();
 
   const onClickCloseModal = () => {
     setIsModal(!isModal);
+    setModalType("");
+    if (setIsForRegisterModal) {
+      setIsForRegisterModal(!isForRegisterModal);
+    }
   };
 
   const props = {

--- a/src/common/components/Modal/RegisterForm/RegisterForm.tsx
+++ b/src/common/components/Modal/RegisterForm/RegisterForm.tsx
@@ -3,8 +3,9 @@ import { COLORS } from "@constants/color";
 import styled from "styled-components";
 import MemberList from "./components/MemberList";
 import ScheduleTable from "./components/ScheduleTable";
-import ButtonItem from "@components/Button/Button.tsx";
-import { CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";
+/*import ButtonItem from "@components/Button/Button.tsx";
+import { CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";*/
+import ButtonGroup from "@components/Button/ButtonGroup.tsx";
 
 const RegisterForm = () => {
   return <RegisterFormView />;
@@ -20,7 +21,7 @@ const RegisterFormView = () => {
         <ScheduleTable />
         <MemberList />
       </Form>
-      <ButtonItem type="scheduleCancel">
+      {/*<ButtonItem type="scheduleCancel">
         <DeleteIcon color={COLORS.gray700} fontSize={25} />
       </ButtonItem>
       <ButtonItem style={{ bottom: "8rem" }} type="toggle">
@@ -28,7 +29,8 @@ const RegisterFormView = () => {
       </ButtonItem>
       <ButtonItem type="toggle">
         <CloseIcon color="white" fontSize={16} />
-      </ButtonItem>
+      </ButtonItem>*/}
+      <ButtonGroup />
     </>
   );
 };

--- a/src/common/components/ViewSchedule/ViewSchedule.tsx
+++ b/src/common/components/ViewSchedule/ViewSchedule.tsx
@@ -3,55 +3,13 @@ import styled from "styled-components";
 import scheduleRed from "/assets/schedule-red.svg";
 import { Image } from "@chakra-ui/react";
 import Typography from "@components/Typography/Typography";
-/*import { AddIcon, CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";
-import ButtonItem from "@components/Button/Button";
-import useStore, { ModalType } from "@stores/store";
-import { useLocation } from "react-router-dom";*/
 import ButtonGroup from "@components/Button/ButtonGroup.tsx";
 
-/*interface ViewScheduleProps {
-  isModal: boolean;
-  onClickToggle: () => void;
-  onClickShowModal: () => void;
-  pathName: string;
-  modalType: ModalType;
-}*/
-
 const ViewSchedule = () => {
-  /*const pathName = useLocation().pathname;
-  const { modalType, setModalType, isModal, setIsModal } = useStore();
-
-  const onClickToggle = () => {
-    if (pathName === "/scheduleRegister") {
-      setModalType("register");
-      setIsModal(!isModal);
-    } else {
-      setIsModal(!isModal);
-      setModalType("");
-    }
-  };
-
-  const onClickShowModal = () => {
-    setModalType("modal");
-  };
-
-  const props = {
-    modalType,
-    isModal,
-    onClickToggle,
-    onClickShowModal,
-    pathName,
-  };*/
   return <ScheduleView />;
 };
 
-const ScheduleView = (/*{
-  modalType,
-  isModal,
-  onClickShowModal,
-  onClickToggle,
-  pathName,
-}: ViewScheduleProps*/) => {
+const ScheduleView = () => {
   return (
     <ViewContainer>
       <ImageWrapper>
@@ -60,36 +18,6 @@ const ScheduleView = (/*{
           등록된 일정이 없습니다!
         </Typography>
       </ImageWrapper>
-      {/*isModal && (
-        <>
-          {pathName === "/scheduleRegister" ? null : (
-            <>
-              <ButtonItem type="scheduleCancel" onClick={onClickShowModal}>
-                <DeleteIcon color={COLORS.gray700} fontSize={25} />
-              </ButtonItem>
-              <ButtonItem
-                style={{ bottom: "8rem" }}
-                type="toggle"
-                onClick={onClickShowModal}
-              >
-                <EditIcon color={COLORS.white} fontSize={25} />
-              </ButtonItem>
-            </>
-          )}
-        </>
-      )*/}
-
-      {/*modalType === "register" ? null : (
-        <>
-          <ButtonItem type="toggle" onClick={onClickToggle}>
-            {isModal ? (
-              <CloseIcon color="white" fontSize={16} />
-            ) : (
-              <AddIcon color="white" fontSize={18} />
-            )}
-          </ButtonItem>
-        </>
-      )*/}
       <ButtonGroup />
     </ViewContainer>
   );

--- a/src/common/components/ViewSchedule/ViewSchedule.tsx
+++ b/src/common/components/ViewSchedule/ViewSchedule.tsx
@@ -2,22 +2,23 @@ import { COLORS } from "@constants/color";
 import styled from "styled-components";
 import scheduleRed from "/assets/schedule-red.svg";
 import { Image } from "@chakra-ui/react";
-import { AddIcon, CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import Typography from "@components/Typography/Typography";
+/*import { AddIcon, CloseIcon, DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import ButtonItem from "@components/Button/Button";
 import useStore, { ModalType } from "@stores/store";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";*/
+import ButtonGroup from "@components/Button/ButtonGroup.tsx";
 
-interface ViewScheduleProps {
+/*interface ViewScheduleProps {
   isModal: boolean;
   onClickToggle: () => void;
   onClickShowModal: () => void;
   pathName: string;
   modalType: ModalType;
-}
+}*/
 
 const ViewSchedule = () => {
-  const pathName = useLocation().pathname;
+  /*const pathName = useLocation().pathname;
   const { modalType, setModalType, isModal, setIsModal } = useStore();
 
   const onClickToggle = () => {
@@ -40,17 +41,17 @@ const ViewSchedule = () => {
     onClickToggle,
     onClickShowModal,
     pathName,
-  };
-  return <ScheduleView {...props} />;
+  };*/
+  return <ScheduleView />;
 };
 
-const ScheduleView = ({
+const ScheduleView = (/*{
   modalType,
   isModal,
   onClickShowModal,
   onClickToggle,
   pathName,
-}: ViewScheduleProps) => {
+}: ViewScheduleProps*/) => {
   return (
     <ViewContainer>
       <ImageWrapper>
@@ -59,7 +60,7 @@ const ScheduleView = ({
           등록된 일정이 없습니다!
         </Typography>
       </ImageWrapper>
-      {isModal && (
+      {/*isModal && (
         <>
           {pathName === "/scheduleRegister" ? null : (
             <>
@@ -76,9 +77,9 @@ const ScheduleView = ({
             </>
           )}
         </>
-      )}
+      )*/}
 
-      {modalType === "register" ? null : (
+      {/*modalType === "register" ? null : (
         <>
           <ButtonItem type="toggle" onClick={onClickToggle}>
             {isModal ? (
@@ -88,7 +89,8 @@ const ScheduleView = ({
             )}
           </ButtonItem>
         </>
-      )}
+      )*/}
+      <ButtonGroup />
     </ViewContainer>
   );
 };
@@ -108,4 +110,3 @@ const ImageWrapper = styled.div`
   flex-direction: column;
   align-items: center;
 `;
-


### PR DESCRIPTION
### ⛳️ Task

- [x] 스케줄 등록폼에서 모달 상태 따로 관리
- [x] 토글, 수정, 삭제 버튼을 그룹으로 묶어 하나의 컴포넌트로 관리

### ✍️ Note
스케줄 등록폼에서 추가적인 모달을 띄울때 전역 상태를 변경해서 모달을 띄우고 닫고 하기에 코드의 복잡성이 많이 증가할 것 같아
스케줄 등록폼에서만 useState로 상태를 관리 하여 모달을 추가적으로 띄우도록 했습니다.
버튼 컴포넌트가 유저 스케줄 등록과 스케줄 등록폼에서 사용 되는데 view 컴포넌트 부분 코드가 너무 길어지기 때문에 그룹으로 묶어서 하나의 컴포넌트로 분리했습니다

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
